### PR TITLE
optimized esx_datastore

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -36,21 +36,19 @@ end)
 
 function GetDataStore(name, owner)
     if not DataStores[name][owner] then
-		MySQL.Sync.fetchAll('SELECT data FROM datastore_data WHERE name = @name AND owner = @owner LIMIT 1', {
+		local result = MySQL.Sync.fetchAll('SELECT data FROM datastore_data WHERE name = @name AND owner = @owner LIMIT 1', {
             ['@name'] = name,
             ['@owner'] = owner
-        }, function(result)
-			if result[1] then
-				DataStores[name][owner] = CreateDataStore(name, owner, json.decode(result[1].data))
-			else
-				MySQL.Sync.execute('INSERT INTO datastore_data (name, owner, data) VALUES (@name, @owner, \'{}\')', {
+        })
+		if result[1] then
+			DataStores[name][owner] = CreateDataStore(name, owner, json.decode(result[1].data))
+		else
+			MySQL.Sync.execute('INSERT INTO datastore_data (name, owner, data) VALUES (@name, @owner, \'{}\')', {
 					['@name'] = name,
             		['@owner'] = owner
-				}, function(result)
-					DataStores[name][owner] = CreateDataStore(name, owner, {})
-				end)
-			end
-		end)
+			})
+			DataStores[name][owner] = CreateDataStore(name, owner, {})
+		end
     end
 
     return DataStores[name][owner]


### PR DESCRIPTION
Thanks to linden we have optimized esx_datastore. Main problem was that it loop trough whole datastore on every player loaded event. Servers with huge amount of data may get some performance problem. Another problem was retrieving datastore. It loops again trough whole datastore variable. 

In my PR i rewrote indexing by using identifier, so no more looping while getting datastore. Also it doesn´t load player datastores at startup. Why to load 30000 rows of data if the player won´t even come to server? So we load only shared datastores on startup. Also we don´t create empty datastores at connect, but after accessing datastore if data doesn´t already exists. 

Take a look at code. Compatibility should remain the same.